### PR TITLE
Run logrotate every 5 minutes instead of hourly

### DIFF
--- a/root-files/opt/flownative/logrotate/sbin/logrotate-cron.sh
+++ b/root-files/opt/flownative/logrotate/sbin/logrotate-cron.sh
@@ -2,7 +2,7 @@
 
 while true; do
     currentMinute=$(date +"%M")
-    if [ "${currentMinute}" == "15" ]; then
+    if [ $(expr ${currentMinute} % 5) -eq 0 ]; then
         "${LOGROTATE_BASE_PATH}/sbin/logrotate" "--state=${LOGROTATE_BASE_PATH}/var/status" "--log=${FLOWNATIVE_LOG_PATH}/logrotate.log" --verbose "${LOGROTATE_BASE_PATH}/etc/logrotate.conf"
         sleep 10
     fi


### PR DESCRIPTION
This makes sure that logrotate runs more often in order to make file size problems less likely.