### PR TITLE
Add Grafana Cloud heartbeat metric push to scheduled build

### DIFF
--- a/.github/workflows/docker.build.bookworm.yaml
+++ b/.github/workflows/docker.build.bookworm.yaml
@@ -83,3 +83,22 @@ jobs:
           to: docker-build-base@flownative.heartbeat.eu.opsgenie.net
           from: Github Actions <noreply@flownative.com>
           body: Build job of ${{github.repository}} completed successfully!
+
+      - name: Push heartbeat metric to Grafana Cloud
+        if: success()
+        env:
+          RW_URL: ${{ secrets.GRAFANA_METRICS_RW_URL }}
+          INSTANCE_ID: ${{ secrets.GRAFANA_METRICS_INSTANCE_ID }}
+          TOKEN: ${{ secrets.GRAFANA_METRICS_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Derive the Influx line-protocol push endpoint from the Prometheus
+          # remote-write endpoint (same account, different host/path).
+          INFLUX_URL="$(printf '%s' "$RW_URL" | sed -e 's#prometheus-#influx-#' -e 's#/api/prom/push#/api/v1/push/influx/write#')"
+          NOW="$(date +%s)"
+          # measurement + field 'seconds' -> metric flownative_ci_last_success_timestamp_seconds
+          curl -sf --retry 3 --retry-all-errors \
+            -u "${INSTANCE_ID}:${TOKEN}" \
+            -H 'Content-Type: text/plain' \
+            "${INFLUX_URL}" \
+            --data-binary "flownative_ci_last_success_timestamp,job=docker-build,image=base seconds=${NOW}"


### PR DESCRIPTION
Adds a step to the scheduled Bookworm build that pushes a
`flownative_ci_last_success_timestamp_seconds{job="docker-build", image="base"}`
gauge (value = build time) to Grafana Cloud after a successful build.

This is part of the OpsGenie → Grafana OnCall migration. Grafana OnCall's native
heartbeats can't cover our needs (max interval 24h, one per integration),
so dead-man switches move to a pushed timestamp metric + a Grafana alert
that fires when the metric is stale for > 3 days and routes to Beach Minor.

Runs **in parallel** with the existing OpsGenie heartbeat mail step; nothing
is removed until the OpsGenie cutover.

- Uses the metrics-publisher token (repo secrets `GRAFANA_METRICS_*`,
  provisioned via infra-core Terraform).
- The push path (Influx line-protocol endpoint derived from the remote-write
  URL, auth, ingestion) was validated live before opening this PR.
- Pilot for the docker-base heartbeat; the remaining images/repos follow the
  same pattern once this is confirmed.